### PR TITLE
Addresses the issue I submitted ealier about triggerqueues and waitFor

### DIFF
--- a/src/main/java/org/javasim/SimulationEntity.java
+++ b/src/main/java/org/javasim/SimulationEntity.java
@@ -67,6 +67,7 @@ public class SimulationEntity extends SimulationProcess
     public final void trigger ()
     {
         _triggered = true;
+        _waiting = false;
     }
 
     /**
@@ -80,14 +81,14 @@ public class SimulationEntity extends SimulationProcess
          * Resume waiting process before this one "dies".
          */
 
-        if (_isWaiting != null)
+        if (_isWaitedOnBy != null)
         {
             // remove from queue for "immediate" activation
 
             try
             {
-                _isWaiting.cancel();
-                _isWaiting.reactivateAt(SimulationProcess.currentTime(), true);
+                _isWaitedOnBy.cancel();
+                _isWaitedOnBy.reactivateAt(SimulationProcess.currentTime(), true);
             }
             catch (RestartException e)
             {
@@ -96,7 +97,7 @@ public class SimulationEntity extends SimulationProcess
             {
             }
 
-            _isWaiting = null;
+            _isWaitedOnBy = null;
         }
 
         super.terminate();
@@ -106,7 +107,7 @@ public class SimulationEntity extends SimulationProcess
     {
         super();
 
-        _isWaiting = null;
+        _isWaitedOnBy = null;
         _interrupted = _triggered = _waiting = false;
     }
 
@@ -151,7 +152,7 @@ public class SimulationEntity extends SimulationProcess
         if (controller == this) // can't wait on self!
             throw new SimulationException("WaitFor cannot wait on self.");
 
-        controller._isWaiting = this; // resume when controller terminates
+        controller._isWaitedOnBy = this; // resume when controller terminates
 
         // make sure this is ready to run
 
@@ -226,12 +227,12 @@ public class SimulationEntity extends SimulationProcess
         _sem.get(this);
     }
 
-    protected SimulationEntity _isWaiting;
+    private SimulationEntity _isWaitedOnBy;
 
     private boolean _interrupted;
 
     private boolean _triggered;
 
-    private boolean _waiting;
+    protected boolean _waiting;
 
 };

--- a/src/main/java/org/javasim/TriggerQueue.java
+++ b/src/main/java/org/javasim/TriggerQueue.java
@@ -99,7 +99,7 @@ public class TriggerQueue
     protected synchronized void insert (SimulationEntity toAdd)
             throws SimulationException
     {
-        if (toAdd._isWaiting != null)
+        if (toAdd._waiting == true)
             throw (new SimulationException("Entity already waiting on event."));
 
         head.add(toAdd);


### PR DESCRIPTION
Fixes a problem with the waitFor(SimulationEntity e) interfering with waitForTrigger(TriggerQueue q).

I also went ahead and renamed the _isWaiting variable to _isWaitedOnBy and made it private to avoid future confusion about what it means.
